### PR TITLE
Feat/generate webp on wp attachement image src

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
         "wp-coding-standards/wpcs": "^2.3",
         "codeception/codeception": "^5.0",
         "codeception/module-phpbrowser": "*",
-        "codeception/module-asserts": "*"
+        "codeception/module-asserts": "*",
+        "monolog/monolog": "^2.9"
     },
     "config": {
         "allow-plugins": {

--- a/src/WebPImageConverter.php
+++ b/src/WebPImageConverter.php
@@ -75,24 +75,50 @@ class WebPImageConverter {
 	 */
 	public function run(): void {
 		add_action( 'add_attachment', [ $this, 'generate_webp_on_add_attachment' ] );
+		add_filter( 'wp_get_attachment_image_src', [ $this, 'generate_webp_on_wp_get_attachment_image_src' ], 10, 4 );
 		add_filter( 'post_thumbnail_html', [ $this, 'generate_webp_on_post_thumbnail_html' ], 10, 5 );
 	}
 
 	/**
 	 * Generate WebP on add_attachment.
 	 *
-	 * @param int $image_id Image ID.
+	 * @param int $attachment_id Image ID.
 	 * @return void
 	 */
-	public function generate_webp_on_add_attachment( $image_id ): void {
+	public function generate_webp_on_add_attachment( $attachment_id ): void {
 		// Get Image ID.
-		$this->id = $image_id;
+		$this->id = $attachment_id;
 
 		// Ensure this is image, then go ahead.
 		$this->is_image_attachment();
 
 		// Generate WebP.
 		$this->convert_to_webp();
+	}
+
+	/**
+	 * Generate WebP on wp_get_attachment_image_src.
+	 *
+	 * @param array|false  $image Array of Image data.
+	 * @param int          $attachment_id Image attachment ID.
+	 * @param string|int[] $size Image size (width & height).
+	 * @param bool         $icon Whether the image should be treated as an icon.
+	 * @return string
+	 */
+	public function generate_webp_on_wp_get_attachment_image_src( $image, $attachment_id, $size, $icon ): string {
+		// Get Image ID.
+		$this->id = $attachment_id;
+
+		// Generate WebP.
+		$this->convert_to_webp();
+
+		// Return WebP Image.
+		if ( file_exists( $this->destination ) ) {
+			$image[0] = $this->relative_destination;
+		}
+
+		// Safely return Image.
+		return $image;
 	}
 
 	/**


### PR DESCRIPTION
### 🎫 Feature

[Branch](https://github.com/chigozieorunta/webp-image-converter/tree/feat/generate-webp-on-wp-attachement-image-src)

### 🗒️ Description

Added a new way to generate WebP when users upload images.

### 🎥 Artifacts <!-- if applicable-->

### ✔️ Checklist
- [] I've included a changelog entry in the readme.txt file. <!-- Confirm that it includes the ticket ID. -->
- [] My code is tested. <!-- Check that tests are passing and DO NOT merge if they're failing. -->